### PR TITLE
Consider file permissions when writing configuration in system tests …

### DIFF
--- a/tests/System/plugins/fs.js
+++ b/tests/System/plugins/fs.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const fspath = require('path');
+const { umask } = require('node:process');
 
 /**
  * Deletes a folder with the given path recursive.
@@ -16,19 +17,36 @@ function deleteFolder(path, config) {
 }
 
 /**
- * Writes the given content to a file for the given path.
+ * Writes the given content to the file with the given path relative to the CMS root folder.
  *
- * @param {string} path The path
- * @param {mixed} content The content
- * @param {object} config The config
+ * If directory entries from the path do not exist, they are created recursively with the file mask 0o777.
+ * If the file already exists, it will be overwritten.
+ * Finally, the given file mode or the default 0o444 is set for the given file.
+ *
+ * @param {string} path The relative file path (e.g. 'images/test-dir/override.jpg')
+ * @param {mixed} content The file content
+ * @param {object} config The Cypress configuration
+ * @param {number} [mode=0o444] The file mode to be used (in octal)
  *
  * @returns null
  */
-function writeFile(path, content, config) {
-  fs.mkdirSync(fspath.dirname(`${config.env.cmsPath}/${path}`), { recursive: true, mode: 0o777 });
-  fs.chmod(fspath.dirname(`${config.env.cmsPath}/${path}`), 0o777);
-  fs.writeFileSync(`${config.env.cmsPath}/${path}`, content);
-  fs.chmod(`${config.env.cmsPath}/${path}`, 0o777);
+function writeFile(path, content, config, mode = 0o444) {
+  const fullPath = fspath.join(config.env.cmsPath, path);
+  // Prologue: Reset process file mode creation mask to ensure the umask value is not subtracted
+  const oldmask = umask(0);
+  // Create missing parent directories with 'rwxrwxrwx'
+  fs.mkdirSync(fspath.dirname(fullPath), { recursive: true, mode: 0o777 });
+  // Check if the file exists
+  if (fs.existsSync(fullPath)) {
+    // Set 'rw-rw-rw-' to be able to overwrite the file
+    fs.chmodSync(fullPath, 0o666);
+  }
+  // Write or overwrite the file on relative path with given content
+  fs.writeFileSync(fullPath, content);
+  // Finally set given file mode or default 'r--r--r--'
+  fs.chmodSync(fullPath, mode);
+  // Epilogue: Restore process file mode creation mask
+  umask(oldmask);
 
   return null;
 }

--- a/tests/System/plugins/index.js
+++ b/tests/System/plugins/index.js
@@ -14,7 +14,7 @@ function setupPlugins(on, config) {
   on('task', {
     queryDB: (query) => db.queryTestDB(query, config),
     cleanupDB: () => db.deleteInsertedItems(config),
-    writeFile: ({ path, content }) => fs.writeFile(path, content, config),
+    writeFile: ({ path, content, mode }) => fs.writeFile(path, content, config, mode),
     deleteFolder: (path) => fs.deleteFolder(path, config),
     getMails: () => mail.getMails(),
     clearEmails: () => mail.clearEmails(),

--- a/tests/System/support/commands/config.js
+++ b/tests/System/support/commands/config.js
@@ -1,10 +1,9 @@
 Cypress.Commands.add('config_setParameter', (parameter, value) => {
-  cy.readFile(`${Cypress.env('cmsPath')}/configuration.php`).then((fileContent) => {
+  const configPath = `${Cypress.env('cmsPath')}/configuration.php`;
+
+  cy.readFile(configPath).then((fileContent) => {
     // Setup the new value
-    let newValue = value;
-    if (typeof value === 'string') {
-      newValue = `'${value}'`;
-    }
+    const newValue = typeof value === 'string' ? `'${value}'` : value;
 
     // The regex to find the line of the parameter
     const regex = new RegExp(`^.*\\$${parameter}\\s.*$`, 'mg');
@@ -12,7 +11,7 @@ Cypress.Commands.add('config_setParameter', (parameter, value) => {
     // Replace the whole line with the new value
     const content = fileContent.replace(regex, `public $${parameter} = ${newValue};`);
 
-    // Write the modified content back to the configuration file
+    // Write the modified content back to the configuration file relative to the CMS root folder
     cy.task('writeFile', { path: 'configuration.php', content });
   });
 });


### PR DESCRIPTION
…(#43466)

* Fix for issue #43465 writing configuration.php

Fix for issue #43465 'Cypress System Tests fail when writing configuration.php' . remember the original file permission
. set 644
. write file
. restore original file permission

additional:
. writing file to ${Cypress.env('cmsPath')}/configuration.php` and no more to 'configuration.php' . error handle file is not existing

* typo

* updated system tests README

* corrected task names

* Update tests/System/README.md

of course, thank you for checking



* deleted failure handler config_setParameter()

deleted failure handler for readFile as it is not needed, tested with chmod 0, Cypress fails with clear reason:

	CypressError: `cy.readFile("./configuration.php")` failed while trying to read the file at the following path:
	`.../43465/joomla-cms/configuration.php`
	The following error occurred:
	> "EACCES: permission denied, open '/Users/hlu/Desktop/no_backup/43465/joomla-cms/configuration.php'"

* typo



* typo



* chain the then()-calls

Chaining the then()-calls for a not so deeply nested code source looks catchy - thank Allon for the recommendation

* adopted code formatting for better readability

* fixing lint:js errors

- deleted console.log statements
- used const for never changing value
- refactored file mask to not use bitwise operation '&'

* fixed lint:testjs errors

* Better fix for configuration.php permission issue

Working with the code when fighting with the drone shows that a `chmod` was already implemented in `writeFile()`. Following changes with this commit:
- Only using `chmod` method synchronously
- Replaced setting directory mode to setting file mode before writing
- Setting file mode only if the file exists
- Having final file mode as parameter with default 0o444
- Using 0o444 as default file mode and not hard-wired 0o777
- The methods `getFilePermissions()` and `changeFilePermissions()` created for this PR earlier are deleted.

Enhancement of the `tests/System/README.md` for troubleshooting three-user-problem in having Cypress running user, web server running user and `root` user.

This commitment has been extensively tested in various combinations. Every test contains:
- Checking error before
- Doing the patch
- Running installation twice and running overall test suite

Tests are:
- macOS 14.5 Sonoma, local with apache & Cypress same user, branch 4.4-dev
  - error before `> EACCES: permission denied, open './configuration.php'`
- Docker, one container with joomla and one container with Cypress, using `root` users inside containers
  - no error before, but `configuration.php` is 777
  - after the patch `configuration.php` is 444 inside container and shown 644 on host
  - tested four times, branches 4.4-dev, 5.1-dev, 5.2-dev and 6.0-dev
- Ubuntu 24.04 LTS local installation, one non-root users running Cypress and another non-root user running Apache, branch 4.4-dev
  - error before `> EACCES: permission denied, open './configuration.php'`
  - need to use `sudo` and need to set `umask 0`, see troubleshooting
- Windows 11 Pro, Laragon with Cmder, branch 4.4-dev
  - error before `> EPERM: operation not permitted, open 'C:\laragon\www\joomla-cms\configuration.php'`

All tests are successful:
- running `Installation.cy.js` twice, checking `configuration.php` 444 and params are set
- running complete system test suite without errors

* configuration.php CMS path relative && umask 0

- corrected mistake task writeFile was used with cmsPath + 'configuration.php'
- extended writeFile to set process umask 0
  - to prevent the 3-user-problem == no need to set umask 0 in sudo anymore

This commitment has been tested in various combinations. Every test contains:
- Checking error before
- Doing the patch
- Running Installation.cy.js only and running overall test suite

Tests are:
- Docker environment with drone images, root running Cypress and www-data running Apache, branch 4.4-dev
  - no error before, but /tests/www/cmysql/configuration.php has 777
- Ubuntu 24.04 LTS local installation, one non-root user running Cypress and another non-root user running Apache, branch 4.4-dev
  - error before `> EACCES: permission denied, open './configuration.php'`
  - need to use `sudo`, see troubleshooting (umask 0 is no more needed)
- Windows 11 Pro, Laragon with Cmder, branch 4.4-dev
  - error before `> EPERM: operation not permitted, open 'C:\laragon\www\joomla-cms\configuration.php'`
  - found out that on the second run cy.exec('rm configuration.php') does not work under Windows
    - deleted file manually and i will create an issue afterwards to avoid enlarging this one
- macOS 14.5 Sonoma, local with apache & Cypress same user, branch 4.4-dev
  - error before `> EACCES: permission denied, open './configuration.php'`

All tests are successful:
- running `Installation.cy.js`, checking `configuration.php` 444 and params are set
- running complete system test suite without errors

---------

Pull Request for Issue # .

### Summary of Changes



### Testing Instructions



### Actual result BEFORE applying this Pull Request



### Expected result AFTER applying this Pull Request



### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
